### PR TITLE
ci: branch checkout and apk sign issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,13 @@ jobs:
           distribution: 'adopt'
           java-version: '17'
           architecture: x64
+          
+      - name: Setup build tool version variable
+        shell: bash
+        run: |
+          BUILD_TOOL_VERSION=$(ls /usr/local/lib/android/sdk/build-tools/ | tail -n 1)
+          echo "BUILD_TOOL_VERSION=$BUILD_TOOL_VERSION" >> $GITHUB_ENV
+          echo Last build tool version is: $BUILD_TOOL_VERSION
 
       - name: Set up Go
         run: |
@@ -79,6 +86,8 @@ jobs:
           alias: ${{ secrets.ALIAS }}
           keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
           keyPassword: ${{ secrets.KEY_PASSWORD }}
+        env:
+          BUILD_TOOLS_VERSION: ${{ env.BUILD_TOOL_VERSION }}
 
       - name: Rename APK
         run:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,6 @@ jobs:
         run: |
           git clone https://github.com/Mythologyli/zju-connect.git
           cd zju-connect
-          git checkout android
           go mod download
           go install golang.org/x/mobile/cmd/gomobile@latest
           go get golang.org/x/mobile/bind@latest


### PR DESCRIPTION
Hi, I encountered errors when trying to use GitHub Action to built the apk, which were resolved by making some fixes to build.yml.

- zju-connect no longer has an android branch, and the AAR can be built successfully without `git checkout` . 
- an error when signing the apk. 

```
Error: Couldnt find the Android build tools @ /usr/local/lib/android/sdk/build-tools/30.0.2
Error: Unable to locate executable file: /usr/local/lib/android/sdk/build-tools/30.0.2/zipalign. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.
```

After checking [this issue](https://github.com/r0adkll/sign-android-release/issues/84), adding an environment variable fixed it.